### PR TITLE
Make FFT + PlaneField class rewrite

### DIFF
--- a/include/core/fft.hpp
+++ b/include/core/fft.hpp
@@ -1,21 +1,69 @@
 #pragma once
 
+#include <cstddef>
+#include <fftw3.h>
+#include <functional>
+
 #include "core/attributes.hpp"
 #include "core/plane_field.hpp"
 
 namespace diffraction {
 
+template<typename Transform>
+class FFTPlan final : NonCopyable {
+  public:
+    FFTPlan(std::size_t xSize, std::size_t ySize) {
+        static_assert("FFTPlan accepts only FFT2D and FFT2DInverse as a template parameter");
+    }
+
+    ~FFTPlan() {
+        fftw_destroy_plan(plan_);
+    }
+
+    DIFFRACTION_NODISCARD const fftw_plan& getPlan() const {
+        return plan_;
+    }
+
+    DIFFRACTION_NODISCARD std::size_t getXSize() const {
+        return xSize_;
+    }
+
+    DIFFRACTION_NODISCARD std::size_t getYSize() const {
+        return ySize_;
+    }
+
+  private:
+    fftw_plan plan_;
+    std::size_t xSize_{0};
+    std::size_t ySize_{0};
+};
+
+class FFT2D;
+class FFT2DInverse;
+
+template<>
+FFTPlan<FFT2D>::FFTPlan(std::size_t xSize, std::size_t ySize);
+
+template<>
+FFTPlan<FFT2DInverse>::FFTPlan(std::size_t xSize, std::size_t ySize);
+
 class FFT2D final : NonCopyable {
   public:
-    FFT2D() = default;
+    FFT2D(const FFTPlan<FFT2D>& plan) : plan_(plan) {}
 
     void transform(PlaneField& input) const;
+  
+  private:
+    std::reference_wrapper<const FFTPlan<FFT2D>> plan_;
 };
 
 class FFT2DInverse final : NonCopyable {
   public:
-    FFT2DInverse() = default;
 
+    FFT2DInverse(const FFTPlan<FFT2DInverse>& plan) : plan_(plan) {}
     void transform(PlaneField& input) const;
+
+  private:
+    std::reference_wrapper<const FFTPlan<FFT2DInverse>> plan_;
 };
 } // namespace diffraction

--- a/include/core/plane_field.hpp
+++ b/include/core/plane_field.hpp
@@ -28,6 +28,7 @@ struct PlainFieldStorage {
 
 class PlaneField : detail::PlainFieldStorage {
   public:
+    // TODO reverse iterators?
     template<typename DataType>
     class Iterator final : public std::random_access_iterator_tag {
       public:
@@ -63,7 +64,7 @@ class PlaneField : detail::PlainFieldStorage {
             return itPointer_ - other.itPointer_;
         }
 
-        reference operator[](difference_type diff) {
+        reference operator[](difference_type diff) const {
             return *(itPointer_ + diff);
         }
 
@@ -101,11 +102,11 @@ class PlaneField : detail::PlainFieldStorage {
             return Iterator<DataType>{itPointer_++};
         }
 
-        reference operator*() {
+        reference operator*() const {
             return *itPointer_;
         }
 
-        pointer operator->() {
+        pointer operator->() const {
             return itPointer_;
         }
 
@@ -117,6 +118,8 @@ class PlaneField : detail::PlainFieldStorage {
 
     using iterator = Iterator<FieldValue>;
     using const_iterator = Iterator<const FieldValue>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     using reference = iterator::reference;
     using const_reference = const_iterator::reference;
     using pointer = iterator::pointer;
@@ -181,6 +184,22 @@ class PlaneField : detail::PlainFieldStorage {
 
     DIFFRACTION_NODISCARD auto end() const {
         return const_iterator{dataFinish_};
+    }
+
+    DIFFRACTION_NODISCARD auto rbegin() {
+        return reverse_iterator{end()};
+    }
+
+    DIFFRACTION_NODISCARD auto rend() {
+        return reverse_iterator{begin()};
+    }
+
+    DIFFRACTION_NODISCARD auto rbegin() const {
+        return const_reverse_iterator{end()};
+    }
+
+    DIFFRACTION_NODISCARD auto rend() const {
+        return const_reverse_iterator{begin()};
     }
 
     DIFFRACTION_NODISCARD RowProxy operator[](std::size_t row) {

--- a/include/core/transform.hpp
+++ b/include/core/transform.hpp
@@ -28,12 +28,12 @@ class Transformable final : NonCopyable {
 
 class MultiplyTransformer final : NonCopyable {
   public:
-    explicit MultiplyTransformer(PlaneField& multiplier) : multiplierRef_(multiplier) {}
+    explicit MultiplyTransformer(const PlaneField& multiplier) : multiplierRef_(multiplier) {}
 
     void transform(PlaneField& input) const;
 
   private:
-    std::reference_wrapper<PlaneField> multiplierRef_;
+    std::reference_wrapper<const PlaneField> multiplierRef_;
 };
 
 class NormTransformer final {

--- a/src/core/fft.cpp
+++ b/src/core/fft.cpp
@@ -22,7 +22,7 @@ FFTPlan<FFT2D>::FFTPlan(std::size_t xSize, std::size_t ySize) : xSize_(xSize), y
                              planArray,
                              planArray,
                              FFTW_FORWARD,
-                             FFTW_ESTIMATE | FFTW_UNALIGNED);
+                             FFTW_ESTIMATE);
 
     fftw_free(planArray);
 
@@ -43,7 +43,7 @@ FFTPlan<FFT2DInverse>::FFTPlan(std::size_t xSize, std::size_t ySize) : xSize_(xS
                              planArray,
                              planArray,
                              FFTW_BACKWARD,
-                             FFTW_ESTIMATE | FFTW_UNALIGNED);
+                             FFTW_ESTIMATE);
 
     fftw_free(planArray);
 

--- a/src/core/fft.cpp
+++ b/src/core/fft.cpp
@@ -9,38 +9,59 @@
 // TODO use fftw_malloc in PlaneField instead of vector to remove FFTW_UNALIGNED
 
 namespace diffraction {
+template<>
+FFTPlan<FFT2D>::FFTPlan(std::size_t xSize, std::size_t ySize) : xSize_(xSize), ySize_(ySize) {
+    // Allocate array only for plan creation due to fftw limitations
+    fftw_complex *planArray = fftw_alloc_complex(xSize_ * ySize_);
+
+    if (!planArray) {
+        DIFFRACTION_CRITICAL("Unable to allocate temporary buffer");
+    }
+
+    plan_ = fftw_plan_dft_2d(ySize_, xSize_,
+                             planArray,
+                             planArray,
+                             FFTW_FORWARD,
+                             FFTW_ESTIMATE | FFTW_UNALIGNED);
+
+    fftw_free(planArray);
+
+    if (!plan_) {
+        DIFFRACTION_CRITICAL("Failed to create FFTW 2D inverse plan");
+    }}
+
+template<>
+FFTPlan<FFT2DInverse>::FFTPlan(std::size_t xSize, std::size_t ySize) : xSize_(xSize), ySize_(ySize) {
+    // Allocate array only for plan creation due to fftw limitations
+    fftw_complex *planArray = fftw_alloc_complex(xSize_ * ySize_);
+
+    if (!planArray) {
+        DIFFRACTION_CRITICAL("Unable to allocate temporary buffer");
+    }
+
+    plan_ = fftw_plan_dft_2d(ySize_, xSize_,
+                             planArray,
+                             planArray,
+                             FFTW_BACKWARD,
+                             FFTW_ESTIMATE | FFTW_UNALIGNED);
+
+    fftw_free(planArray);
+
+    if (!plan_) {
+        DIFFRACTION_CRITICAL("Failed to create FFTW 2D inverse plan");
+    }
+}
+
 void FFT2D::transform(PlaneField& input) const {
     auto *dataPtr = &fieldValueToFftw(*input.getRawData());
 
-    fftw_plan plan_ = fftw_plan_dft_2d(input.getYSize(), input.getXSize(),
-                                       dataPtr,
-                                       dataPtr,
-                                       FFTW_FORWARD,
-                                       FFTW_ESTIMATE | FFTW_UNALIGNED);
-
-    if (!plan_) {
-        DIFFRACTION_CRITICAL("Failed to create FFTW plan");
-    }
-
-    fftw_execute_dft(plan_, dataPtr, dataPtr);
-    fftw_destroy_plan(plan_);
+    fftw_execute_dft(plan_.get().getPlan(), dataPtr, dataPtr);
 }
 
 void FFT2DInverse::transform(PlaneField& input) const {
     auto *dataPtr = &fieldValueToFftw(*input.getRawData());
 
-    fftw_plan plan_ = fftw_plan_dft_2d(input.getYSize(), input.getXSize(),
-                                       dataPtr,
-                                       dataPtr,
-                                       FFTW_BACKWARD,
-                                       FFTW_ESTIMATE | FFTW_UNALIGNED);
-
-    if (!plan_) {
-        DIFFRACTION_CRITICAL("Failed to create FFTW plan");
-    }
-
-    fftw_execute_dft(plan_, dataPtr, dataPtr);
-    fftw_destroy_plan(plan_);
+    fftw_execute_dft(plan_.get().getPlan(), dataPtr, dataPtr);
 
     double normCoeff = input.getXSize() * input.getYSize();
 

--- a/src/core/plane_field.cpp
+++ b/src/core/plane_field.cpp
@@ -1,20 +1,77 @@
 #include <algorithm>
+#include <fftw3.h>
+#include <utility>
 
 #include "core/plane_field.hpp"
 #include "core/attributes.hpp"
+#include "core/types.hpp"
 
 namespace diffraction {
-    PlaneField::PlaneField(std::size_t xSize, std::size_t ySize, const FieldValue *rawData) : 
-        xSize_(xSize), ySize_(ySize), fieldValues_(xSize * ySize) {
+namespace detail {
+PlainFieldStorage::PlainFieldStorage(std::size_t storageSize) {
+    // Allocate aligned storage
+    data_ = reinterpret_cast<FieldValue *>(fftw_alloc_complex(storageSize));
 
-        if (rawData == nullptr) {
-            DIFFRACTION_CRITICAL("rawData pointer is nullptr");
-        }
-
-        if (xSize == 0 || ySize == 0) {
-            return;
-        }
-    
-        std::copy(rawData, rawData + fieldValues_.size(), fieldValues_.begin());
+    if (!data_) {
+        DIFFRACTION_CRITICAL("PlaneField allocation error");
     }
+
+    dataFinish_ = data_ + storageSize;
+}
+
+PlainFieldStorage::~PlainFieldStorage() {
+    fftw_free(data_);
+}
+
+PlainFieldStorage::PlainFieldStorage(const PlainFieldStorage& other) : PlainFieldStorage(other.dataFinish_ - other.data_) {
+    std::copy(other.data_, other.dataFinish_, data_);
+}
+
+PlainFieldStorage& PlainFieldStorage::operator=(const PlainFieldStorage& other) {
+    auto otherSize = other.dataFinish_ - other.data_;
+
+    if (dataFinish_ - data_ != otherSize) {
+        // Reallocate storage
+        fftw_free(data_);
+        data_ = reinterpret_cast<FieldValue *>(fftw_alloc_complex(otherSize));
+
+        if (!data_) {
+            DIFFRACTION_CRITICAL("PlaneField reallocation error");
+        }
+
+        dataFinish_ = other.dataFinish_;
+    }
+
+    std::copy(other.data_, other.dataFinish_, data_);
+    
+    return *this;
+}
+
+PlainFieldStorage::PlainFieldStorage(PlainFieldStorage&& other) : data_(nullptr), dataFinish_(nullptr) {
+    std::swap(dataFinish_, other.dataFinish_);
+    std::swap(data_, other.data_);
+}
+
+PlainFieldStorage& PlainFieldStorage::operator=(PlainFieldStorage&& other) {
+    std::swap(dataFinish_, other.dataFinish_);
+    std::swap(data_, other.data_);
+
+    return *this;
+}
+} // namespace detail
+
+PlaneField::PlaneField(std::size_t xSize, std::size_t ySize, const FieldValue *rawData) : 
+    PlainFieldStorage(xSize * ySize), xSize_(xSize), ySize_(ySize) {
+
+    if (rawData == nullptr) {
+        DIFFRACTION_CRITICAL("rawData pointer is nullptr");
+    }
+
+    if (xSize == 0 || ySize == 0) {
+        return;
+    }
+
+    auto dataSize = dataFinish_ - data_;
+    std::copy(rawData, rawData + dataSize, data_);
+}
 }

--- a/src/core/transform.cpp
+++ b/src/core/transform.cpp
@@ -14,7 +14,8 @@ void MultiplyTransformer::transform(PlaneField& input) const {
         DIFFRACTION_CRITICAL("X size of multiplied plane fields is not equal");
     }
 
-    for (auto inputIt = input.begin(), multiplierIt = multiplier.begin(), inputEnd = input.end();
+    auto multiplierIt = multiplier.begin();
+    for (auto inputIt = input.begin(), inputEnd = input.end();
          inputIt != inputEnd; ++inputIt, ++multiplierIt) {
 
         *inputIt *= *multiplierIt;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,10 +41,6 @@ int main() {
 
     sf::Sprite textureSprite{texture};
 
-    auto aaa = texturePixels.end();
-    aaa++;
-    texturePixels.rend();
-
     diffraction::MonochromaticField resultField{kWindowWidth, kWindowHeight, kUsedWavelength};
     for (auto& value : resultField) {
         value = 1.0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ int main() {
 
     auto aaa = texturePixels.end();
     aaa++;
+    texturePixels.rend();
 
     diffraction::MonochromaticField resultField{kWindowWidth, kWindowHeight, kUsedWavelength};
     for (auto& value : resultField) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,9 @@ int main() {
 
     sf::Sprite textureSprite{texture};
 
+    auto aaa = texturePixels.end();
+    aaa++;
+
     diffraction::MonochromaticField resultField{kWindowWidth, kWindowHeight, kUsedWavelength};
     for (auto& value : resultField) {
         value = 1.0;

--- a/tests/fft_tests.cpp
+++ b/tests/fft_tests.cpp
@@ -21,7 +21,8 @@ TEST(FFT2DTest, ForwardTransform) {
         }
     }
 
-    diffraction::FFT2D fft;
+    diffraction::FFTPlan<diffraction::FFT2D> plan{kSize, kSize};
+    diffraction::FFT2D fft{plan};
     fft.transform(input);
 
     for (std::size_t y = 0; y < kSize; ++y) {
@@ -41,7 +42,8 @@ TEST(FFT2DTest, InverseTransform) {
         }
     }
 
-    diffraction::FFT2DInverse fftInverse;
+    diffraction::FFTPlan<diffraction::FFT2DInverse> plan{kSize, kSize};
+    diffraction::FFT2DInverse fftInverse{plan};
     fftInverse.transform(input);
 
     const double expected_value = 1.0;

--- a/tests/plane_field_tests.cpp
+++ b/tests/plane_field_tests.cpp
@@ -1,0 +1,69 @@
+#include <complex>
+#include <gtest/gtest.h>
+
+#include "core/plane_field.hpp"
+
+namespace {
+constexpr auto kDefaultSize = 4;
+constexpr std::complex<double> kDefaultRawData[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+}
+
+TEST(PlaneFieldTest, Construction) {
+    EXPECT_NO_THROW({
+        diffraction::PlaneField field1(kDefaultSize, kDefaultSize);
+    });
+
+
+    EXPECT_NO_THROW({
+        diffraction::PlaneField field2(kDefaultSize, kDefaultSize, kDefaultRawData);
+    });
+}
+
+TEST(PlaneFieldTest, Iteration) {
+    diffraction::PlaneField field(kDefaultSize, kDefaultSize, kDefaultRawData);
+    
+    std::size_t acc = 1;
+
+    for (auto& value : field) {
+        EXPECT_EQ(value.real(), acc++);
+    }
+
+    acc = 1;
+
+    for (auto y = 0; y < field.getYSize(); ++y) {
+        for (auto x = 0; x < field.getXSize(); ++x) {
+            EXPECT_EQ(field[y][x].real(), acc++);
+        }
+    }
+}
+
+TEST(PlaneFieldTest, Iterators) {
+    diffraction::PlaneField field(kDefaultSize, kDefaultSize, kDefaultRawData);
+    
+    auto it = field.begin();
+
+    EXPECT_EQ(it->real(), 1);
+
+    EXPECT_EQ((*it++).real(), 1);
+    EXPECT_EQ((*it).real(), 2);
+    EXPECT_EQ((++it)->real(), 3);
+
+    EXPECT_EQ((*it--).real(), 3);
+    EXPECT_EQ((--it)->real(), 1);
+
+    EXPECT_EQ(it[0].real(), 1);
+    EXPECT_EQ(it[5].real(), 6);
+
+    EXPECT_EQ((it + 3)->real(), 4);
+
+    it += 3;
+
+    EXPECT_EQ((it - 1)->real(), 3);
+
+    it -= 3;
+
+    EXPECT_EQ(it->real(), 1);
+
+    EXPECT_EQ(it, field.begin());
+    EXPECT_NE(it, field.end());
+}

--- a/tests/plane_field_tests.cpp
+++ b/tests/plane_field_tests.cpp
@@ -35,6 +35,11 @@ TEST(PlaneFieldTest, Iteration) {
             EXPECT_EQ(field[y][x].real(), acc++);
         }
     }
+
+    acc = 16;
+    for (auto it = field.rbegin(), end = field.rend(); it != end; it++) {
+        EXPECT_EQ(it->real(), acc--);
+    }
 }
 
 TEST(PlaneFieldTest, Iterators) {
@@ -66,4 +71,15 @@ TEST(PlaneFieldTest, Iterators) {
 
     EXPECT_EQ(it, field.begin());
     EXPECT_NE(it, field.end());
+
+    *it = 0;
+    EXPECT_EQ(it->real(), 0);
+
+    auto rIt = field.rbegin();
+
+    EXPECT_EQ(rIt->real(), 16);
+    EXPECT_EQ((++rIt)->real(), 15);
+
+    *rIt = 0;
+    EXPECT_EQ(rIt->real(), 0);
 }


### PR DESCRIPTION
Create and FFTPlan class to efficiently perform FFT without constructing fftw_plan from scratch every time. Rewrite PlaneField class to use fftw_malloc to allocate internal buffer with respect to fftw alignment requirements. Add unit tests for the PlaneField class.